### PR TITLE
Bedre asserts av statuskode i tester

### DIFF
--- a/apps/rekrutteringstreff-api/src/test/kotlin/no/nav/toi/rekrutteringstreff/eier/RekrutteringstreffEierTest.kt
+++ b/apps/rekrutteringstreff-api/src/test/kotlin/no/nav/toi/rekrutteringstreff/eier/RekrutteringstreffEierTest.kt
@@ -7,15 +7,16 @@ import com.github.kittinunf.result.Result
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.toi.App
 import no.nav.toi.AuthenticationConfiguration
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.*
 import no.nav.toi.ObjectMapperProvider.mapper
-import no.nav.toi.rekrutteringstreff.TestDatabase
+import no.nav.toi.assertStatuscodeEquals
 import no.nav.toi.nowOslo
 import no.nav.toi.rekrutteringstreff.OpprettRekrutteringstreffDto
 import no.nav.toi.rekrutteringstreff.RekrutteringstreffRepository
+import no.nav.toi.rekrutteringstreff.TestDatabase
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.*
 import java.net.HttpURLConnection.HTTP_CREATED
-import java.util.UUID
+import java.util.*
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class RekrutteringstreffEierTest {
@@ -250,7 +251,7 @@ class RekrutteringstreffEierTest {
     )
 
     @Test
-    fun unauthorizedHentEiere() {
+    fun autentiseringHentEiere() {
         // Bruker et dummy UUID
         val dummyId = UUID.randomUUID().toString()
         val (_, response, _) = Fuel.get("http://localhost:$appPort/api/rekrutteringstreff/$dummyId/eiere")
@@ -260,7 +261,7 @@ class RekrutteringstreffEierTest {
     }
 
     @Test
-    fun unauthorizedLeggTilEiere() {
+    fun autentiseringLeggTilEiere() {
         val dummyId = UUID.randomUUID().toString()
         val (_, response, _) = Fuel.put("http://localhost:$appPort/api/rekrutteringstreff/$dummyId/eiere")
             .body(mapper.writeValueAsString("""["A123456"]"""))
@@ -270,12 +271,12 @@ class RekrutteringstreffEierTest {
     }
 
     @Test
-    fun unauthorizedSlettEier() {
+    fun autentiseringSlettEier() {
         val dummyId = UUID.randomUUID().toString()
         val navIdent = "A123456"
-        val (_, response, _) = Fuel.delete("http://localhost:$appPort/api/rekrutteringstreff/$dummyId/eiere/$navIdent")
+        val (_, response, result) = Fuel.delete("http://localhost:$appPort/api/rekrutteringstreff/$dummyId/eiere/$navIdent")
             .header("Authorization", "Bearer invalidtoken")
             .responseString()
-        assertThat(response.statusCode).isEqualTo(401)
+        assertStatuscodeEquals(401, response, result)
     }
 }

--- a/apps/rekrutteringstreff-api/src/test/kotlin/no/nav/toi/testutils.kt
+++ b/apps/rekrutteringstreff-api/src/test/kotlin/no/nav/toi/testutils.kt
@@ -8,8 +8,8 @@ import com.github.kittinunf.result.Result.Success
 import org.assertj.core.api.Assertions.assertThat
 
 /**
- * Denne funksjonens eksistensberettigelse er å få kastet exception når et HTTP kall har feilet uten at vi har fått noen
- * responsstatuskode, f.eks. java.net.SocketException: Unexpected end of file from server */
+ * Denne funksjonens eksistensberettigelse er å få kastet den underliggende exception når et HTTP kall har feilet uten
+ * at vi har fått noen responsstatuskode, f.eks. java.net.SocketException: Unexpected end of file from server */
 fun assertStatuscodeEquals(
     expectedStatuscode: Int,
     actualResponse: Response,

--- a/apps/rekrutteringstreff-api/src/test/kotlin/no/nav/toi/testutils.kt
+++ b/apps/rekrutteringstreff-api/src/test/kotlin/no/nav/toi/testutils.kt
@@ -1,0 +1,26 @@
+package no.nav.toi
+
+import com.github.kittinunf.fuel.core.FuelError
+import com.github.kittinunf.fuel.core.Response
+import com.github.kittinunf.result.Result
+import com.github.kittinunf.result.Result.Failure
+import com.github.kittinunf.result.Result.Success
+import org.assertj.core.api.Assertions.assertThat
+
+/**
+ * Denne funksjonens eksistensberettigelse er å få kastet exception når et HTTP kall har feilet uten at vi har fått noen
+ * responsstatuskode, f.eks. java.net.SocketException: Unexpected end of file from server */
+fun assertStatuscodeEquals(
+    expectedStatuscode: Int,
+    actualResponse: Response,
+    actualResult: Result<*, FuelError>
+) {
+    when (actualResult) {
+        is Success -> assertThat(expectedStatuscode).isEqualTo(actualResponse.statusCode)
+        is Failure -> if (actualResponse.statusCode == -1) {
+            throw actualResult.error
+        } else {
+            assertThat(expectedStatuscode).isEqualTo(actualResponse.statusCode)
+        }
+    }
+}


### PR DESCRIPTION
Kaster riktig exception når HTTP kall feiler uten at vi mottar responsstatuskode.