### PR TITLE
chore(nais): fjern CPU-limit fra rekrutteringstreff-api

### DIFF
--- a/apps/rekrutteringstreff-api/.nais/nais.yaml
+++ b/apps/rekrutteringstreff-api/.nais/nais.yaml
@@ -26,7 +26,6 @@ spec:
     max: {{ max_replicas }}
   resources:
     limits:
-      cpu: 3000m
       memory: 2048Mi
     requests:
       cpu: 100m


### PR DESCRIPTION
Følger Nav-føring om at CPU kun skal ha requests, aldri limits. CPU-throttling under last gir uforutsigbar latens. Memory-limit beholdes for å hindre OOM-spredning på noden.