### PR TITLE
build: SHA-pin GitHub Actions i deploy-template.yaml

### DIFF
--- a/.github/workflows/deploy-template.yaml
+++ b/.github/workflows/deploy-template.yaml
@@ -20,9 +20,9 @@ jobs:
       image: ${{ steps.docker-build-push.outputs.image }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Java v21.x
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: 'temurin'
           java-version: '21.x'
@@ -33,7 +33,7 @@ jobs:
           chmod +x ./gradlew
           ./gradlew :apps:${{ inputs.app_name }}:test :apps:${{ inputs.app_name }}:build
       - name: Push docker image to GAR
-        uses: nais/docker-build-push@v0
+        uses: nais/docker-build-push@cd5ec5663feb0e05c3fa374d1fb442605b046c6b # v0
         id: docker-build-push
         with:
           team: toi
@@ -50,8 +50,8 @@ jobs:
     if: github.ref == 'refs/heads/main' || github.ref == inputs.deploy_dev_branch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: nais/deploy/actions/deploy@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # v2
         env:
           CLUSTER: dev-gcp
           RESOURCE: apps/${{ inputs.app_name }}/.nais/nais.yaml
@@ -64,8 +64,8 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: nais/deploy/actions/deploy@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1 # v2
         env:
           CLUSTER: prod-gcp
           RESOURCE: apps/${{ inputs.app_name }}/.nais/nais.yaml,apps/${{ inputs.app_name }}/.nais/alerts.yaml


### PR DESCRIPTION
Pinner alle actions til full commit-SHA for supply chain-beskyttelse i tråd med Nav security-instruksen.

- actions/checkout v4.2.2 → 11bd71901bbe5b1630ceea73d27597364c9af683
- actions/setup-java v4.7.1 → c5195efecf7bdfc987ee8bae7a71cb8b11521c00
- nais/docker-build-push v0 → cd5ec5663feb0e05c3fa374d1fb442605b046c6b
- nais/deploy/actions/deploy v2 → fa754451577294aae42872a69b888b3470478ec1

SHAene er hentet fra releasene, jeg har manuelt verifisert at det er korrekte ved å gå inn på de følgende sidene:
https://github.com/actions/checkout/releases/tag/v4.2.2
https://github.com/actions/setup-java/releases/tag/v4.7.1
https://github.com/nais/docker-build-push/releases/tag/v0
https://github.com/nais/deploy/releases/tag/v2

At man skal SHA-pinne actionene er definert i en instruksjons-fil for nav-agenten her:  
https://github.com/navikt/copilot/blob/main/.github/instructions/github-actions.instructions.md#action-pinning