### PR TITLE
Fjern annet som ansettelsesform

### DIFF
--- a/.github/workflows/deploy-rekrutteringstreff-api.yaml
+++ b/.github/workflows/deploy-rekrutteringstreff-api.yaml
@@ -14,7 +14,7 @@ jobs:
     uses: ./.github/workflows/deploy-template.yaml
     with:
       app_name: ${{ github.workflow }}
-      deploy_dev_branch: refs/heads/ta_bort_kontorsjekk
+      deploy_dev_branch: refs/heads/fjern-annet
     secrets: inherit
     permissions:
       contents: read

--- a/apps/rekrutteringstreff-api/src/main/kotlin/no/nav/toi/arbeidsgiver/ArbeidsgiverController.kt
+++ b/apps/rekrutteringstreff-api/src/main/kotlin/no/nav/toi/arbeidsgiver/ArbeidsgiverController.kt
@@ -357,7 +357,7 @@ class ArbeidsgiverController(
         ctx.authenticatedUser().verifiserAutorisasjon(Rolle.ARBEIDSGIVER_RETTET, Rolle.JOBBSØKER_RETTET)
         ctx.status(200).json(
             BehovMetadataDto(
-                ansettelsesformer = Ansettelsesform.entries.map { it.apiNavn },
+                ansettelsesformer = Ansettelsesform.entries.filter { it != Ansettelsesform.ANNET }.map { it.apiNavn },
                 arbeidssprak = Arbeidssprak.verdier,
             )
         )

--- a/apps/rekrutteringstreff-api/src/main/kotlin/no/nav/toi/arbeidsgiver/ArbeidsgiverController.kt
+++ b/apps/rekrutteringstreff-api/src/main/kotlin/no/nav/toi/arbeidsgiver/ArbeidsgiverController.kt
@@ -345,7 +345,7 @@ class ArbeidsgiverController(
             content = [OpenApiContent(
                 from = BehovMetadataDto::class,
                 example = """{
-              "ansettelsesformer": ["Fast", "Vikariat", "Engasjement", "Prosjekt", "Åremål", "Sesong", "Feriejobb", "Trainee", "Lærling", "Selvstendig næringsdrivende", "Annet"],
+              "ansettelsesformer": ["Fast", "Vikariat", "Engasjement", "Prosjekt", "Åremål", "Sesong", "Feriejobb", "Trainee", "Lærling", "Selvstendig næringsdrivende"],
               "arbeidssprak": ["Norsk", "Engelsk", "Tysk", "Polsk", "Arabisk"]
             }"""
             )]

--- a/apps/rekrutteringstreff-api/src/test/kotlin/no/nav/toi/arbeidsgiver/ArbeidsgiversBehovTest.kt
+++ b/apps/rekrutteringstreff-api/src/test/kotlin/no/nav/toi/arbeidsgiver/ArbeidsgiversBehovTest.kt
@@ -104,10 +104,11 @@ class ArbeidsgiversBehovTest {
 
             assertThat(response.statusCode()).isEqualTo(HTTP_OK)
             val metadata = JacksonConfig.mapper.readValue(response.body(), BehovMetadataDto::class.java)
-            assertThat(metadata.ansettelsesformer).containsExactlyElementsOf(Ansettelsesform.entries.map { it.apiNavn })
+            assertThat(metadata.ansettelsesformer).containsExactlyElementsOf(Ansettelsesform.entries.filter { it != Ansettelsesform.ANNET }.map { it.apiNavn })
             assertThat(metadata.arbeidssprak).containsExactlyElementsOf(Arbeidssprak.verdier)
             assertThat(metadata.arbeidssprak).contains("Tysk", "Polsk", "Arabisk")
             assertThat(metadata.arbeidssprak).doesNotContain("Annet")
+            assertThat(metadata.ansettelsesformer).doesNotContain("Annet")
         }
     }
 


### PR DESCRIPTION
Det er kun fjernet slik at ikke nye arbeidsgiverbehov får opp denne verdien. Eksisterende behov som har valgt annet vil fremdeles være slik de er. 